### PR TITLE
Add support for redis>=5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        redis-version: [ ">=4.5.0,<5", ">=5,<7", ">=7,<8" ]
         os: [ubuntu-latest]
 
     steps:
@@ -28,6 +29,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        pip install "redis${{ matrix.redis-version }}"
         pip install -r requirements.txt
         pip install coveralls
 
@@ -38,7 +40,7 @@ jobs:
       run: coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COVERALLS_FLAG_NAME: ${{ matrix.os }} - ${{ matrix.python-version }}
+        COVERALLS_FLAG_NAME: ${{ matrix.os }} - ${{ matrix.python-version }} - ${{ matrix.redis-version }}
         COVERALLS_PARALLEL: true
 
   lint:
@@ -89,7 +91,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.12'
+          python-version: '3.14'
 
       - name: Install setuptools
         run: python -m pip install --upgrade setuptools wheel twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-casbin>=0.8.1
-redis>=4.5.0
+casbin~=1.18
+redis>=4.5.2,<8


### PR DESCRIPTION
- Bump requirements to match the redis-watcher (https://github.com/pycasbin/redis-watcher/pull/17)

Note: Out of an abundance of caution, I've also added a matrix to test every major release of the redis library. It seems overkill to me, but I wanted to be thorough.